### PR TITLE
Add the default config for `jigsaw_pieces_dir`

### DIFF
--- a/jigsaw_puzzle_solver/solve_puzzle.py
+++ b/jigsaw_puzzle_solver/solve_puzzle.py
@@ -20,7 +20,8 @@ DEFAULT_CONFIG = {
         "output_dir": "images_out",
         "debug": False,
         "show_assembly_animation": True,
-        "animation_interval_millis": 200
+        "animation_interval_millis": 200,
+        "jigsaw_pieces_dir": "jigsaw_pieces"
     }
 }
 


### PR DESCRIPTION
The program `solve_puzzle.py` doesn't work without config file because the default value of `jigsaw_pieces_dir` is not provided.
I added default value for `jigsaw_pieces_dir` with respect for `create_jigsaw_pieces.py`.